### PR TITLE
Bump amqp

### DIFF
--- a/dist/amqp-client.js
+++ b/dist/amqp-client.js
@@ -110,7 +110,7 @@ export class AMQPClient {
             if (!this.producer) {
                 this.producer = await this.getProducerChannel();
             }
-            this.logger.info(`📨 Sending message to queue: ${queueName}`);
+            this.logger.debug(`📨 Sending message to queue: ${queueName}`);
             return this.producer.sendToQueue(queueName, Buffer.from(JSON.stringify(message)), {
                 headers,
                 correlationId,

--- a/dist/index.js
+++ b/dist/index.js
@@ -9291,7 +9291,7 @@ class AMQPClient {
             if (!this.producer) {
                 this.producer = await this.getProducerChannel();
             }
-            this.logger.info(`📨 Sending message to queue: ${queueName}`);
+            this.logger.debug(`📨 Sending message to queue: ${queueName}`);
             return this.producer.sendToQueue(queueName, Buffer.from(JSON.stringify(message)), {
                 headers,
                 correlationId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundernest-amqp-client",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "AMQP Client",
   "author": "FounderNest",
   "default": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "amqplib": "^0.10.5"
+    "amqplib": "^0.10.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/src/amqp-client.ts
+++ b/src/amqp-client.ts
@@ -24,12 +24,19 @@ export class AMQPClient implements AMQPClientInterface {
   private readonly logger: AMQPClientLoggerInterface
 
   constructor({ logger = console, ...options }: AMQPClientArgs) {
-    this.options = {
-      ...options,
+    // Define default options
+    const defaultOptions = {
       reconnection: {
         initialDelay: 1000,
         maxDelay: 32000,
-        maxAttempts: 5,
+        maxAttempts: 50,
+      },
+    }
+    this.options = {
+      ...options,
+      reconnection: {
+        ...defaultOptions.reconnection,
+        ...(options.reconnection ?? {}),
       },
       // This config must remain constant between all the services using the queue, that's why is constant.
       messageExpiration: {

--- a/src/amqp-client.ts
+++ b/src/amqp-client.ts
@@ -144,7 +144,7 @@ export class AMQPClient implements AMQPClientInterface {
       if (!this.producer) {
         this.producer = await this.getProducerChannel()
       }
-      this.logger.info(`📨 Sending message to queue: ${queueName}`)
+      this.logger.debug(`📨 Sending message to queue: ${queueName}`)
 
       return this.producer.sendToQueue(queueName, Buffer.from(JSON.stringify(message)), {
         headers,

--- a/src/amqp-client.ts
+++ b/src/amqp-client.ts
@@ -26,13 +26,10 @@ export class AMQPClient implements AMQPClientInterface {
   constructor({ logger = console, ...options }: AMQPClientArgs) {
     this.options = {
       ...options,
-      // Constants for exponential backoff strategy.
       reconnection: {
-        // 5 retries in 32 seconds max
-        // Retry in 1, 2, 4, 8, 16 seconds
         initialDelay: 1000,
         maxDelay: 32000,
-        maxAttempts: 50,
+        maxAttempts: 5,
       },
       // This config must remain constant between all the services using the queue, that's why is constant.
       messageExpiration: {

--- a/src/amqp-client.types.ts
+++ b/src/amqp-client.types.ts
@@ -50,12 +50,6 @@ export interface ConnectionOptions {
   password: string
   /** The virtual host to connect to (default: '/') */
   vhost?: string
-}
-
-/**
- * Constants used for AMQP connection and message handling configuration.
- */
-export type ConnectionConstants = {
   /** Configuration for connection retry behavior */
   reconnection: {
     /** Initial delay in milliseconds before the first reconnection attempt */
@@ -65,6 +59,12 @@ export type ConnectionConstants = {
     /** Maximum delay in milliseconds between reconnection attempts */
     maxDelay: number
   }
+}
+
+/**
+ * Constants used for AMQP connection and message handling configuration.
+ */
+export type ConnectionConstants = {
   /** Message handling configuration */
   messageExpiration: {
     /** Time-to-live in milliseconds for messages in the main queue */

--- a/tests/amqp-client.spec.ts
+++ b/tests/amqp-client.spec.ts
@@ -245,7 +245,13 @@ describe('AMQPClient', () => {
 
     it('should attempt the specified number of reconnection attempts', async () => {
       connectMock.mockRejectedValue(new Error('Connection failed'))
-      const client = generateClient()
+      const client = generateClient({
+        reconnection: {
+          initialDelay: 1,
+          maxDelay: 10,
+          maxAttempts: 5,
+        },
+      })
 
       await client.sendMessage('test-queue', { key: 'value' })
 


### PR DESCRIPTION
- Change success messages from `info` to `debug`.
- Bump `amqp` library to 0.10.7 (non breaking changes).
- Make reconnect params optional arguments with default values so we can override them.
- Fix tests.