### PR TITLE
Implement priority property in AMQP messages

### DIFF
--- a/dist/amqp-client.d.ts
+++ b/dist/amqp-client.d.ts
@@ -16,7 +16,7 @@ export declare class AMQPClient implements AMQPClientInterface {
     private reconnect;
     private calculateBackoffDelay;
     close(): Promise<void>;
-    sendMessage<T extends object>(queueName: string, message: T, { headers, correlationId }?: MessagePublishOptions): Promise<boolean>;
+    sendMessage<T extends object>(queueName: string, message: T, { headers, correlationId, priority }?: MessagePublishOptions): Promise<boolean>;
     createListener<T extends object>(queueName: string, onMessage: (msg: AMQPMessage<T>) => Promise<boolean>, options?: ConsumeOptions): Promise<void>;
     private getProducerChannel;
     private getConsumerChannel;

--- a/dist/amqp-client.js
+++ b/dist/amqp-client.js
@@ -114,7 +114,7 @@ export class AMQPClient {
             this.connection = null;
         }
     }
-    async sendMessage(queueName, message, { headers, correlationId } = {}) {
+    async sendMessage(queueName, message, { headers, correlationId, priority } = {}) {
         try {
             if (!this.producer) {
                 this.producer = await this.getProducerChannel(queueName);
@@ -123,6 +123,7 @@ export class AMQPClient {
             return this.producer.sendToQueue(queueName, Buffer.from(JSON.stringify(message)), {
                 headers,
                 correlationId,
+                priority,
                 persistent: true,
                 deliveryMode: 2,
                 contentType: 'application/json',

--- a/dist/amqp-client.types.d.ts
+++ b/dist/amqp-client.types.d.ts
@@ -2,13 +2,13 @@
  * Represents a message received from an AMQP queue, containing the message content and metadata.
  * @template T - The type of the message content
  */
-export interface AMQPMessage<T = any> {
+export interface AMQPMessage<T = unknown> {
     /** The deserialized message content */
     content: T;
     /** Metadata associated with the message */
     metadata: {
         /** Optional headers attached to the message */
-        headers?: Record<string, any>;
+        headers?: Record<string, unknown>;
         /** Unique identifier used for message correlation and tracking */
         correlationId?: string;
         /** Indicates whether this message has been redelivered after a failed processing attempt */
@@ -20,9 +20,11 @@ export interface AMQPMessage<T = any> {
  */
 export interface MessagePublishOptions {
     /** Custom headers to attach to the message */
-    headers?: Record<string, any>;
+    headers?: Record<string, unknown>;
     /** Unique identifier for message correlation and tracking */
     correlationId?: string;
+    /** Message priority (0-255, where higher numbers indicate higher priority) */
+    priority?: number;
 }
 /**
  * Configuration options for consuming messages from an AMQP queue.

--- a/dist/index.js
+++ b/dist/index.js
@@ -7820,7 +7820,7 @@ credentials$1.external = function() {
 var name = "amqplib";
 var homepage = "http://amqp-node.github.io/amqplib/";
 var main = "./channel_api.js";
-var version = "0.10.7";
+var version = "0.10.8";
 var description = "An AMQP 0-9-1 (e.g., RabbitMQ) library and client.";
 var repository = {
 	type: "git",
@@ -9295,7 +9295,7 @@ class AMQPClient {
             this.connection = null;
         }
     }
-    async sendMessage(queueName, message, { headers, correlationId } = {}) {
+    async sendMessage(queueName, message, { headers, correlationId, priority } = {}) {
         try {
             if (!this.producer) {
                 this.producer = await this.getProducerChannel(queueName);
@@ -9304,6 +9304,7 @@ class AMQPClient {
             return this.producer.sendToQueue(queueName, Buffer.from(JSON.stringify(message)), {
                 headers,
                 correlationId,
+                priority,
                 persistent: true,
                 deliveryMode: 2,
                 contentType: 'application/json',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundernest-amqp-client",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "AMQP Client",
   "author": "FounderNest",
   "default": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundernest-amqp-client",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "AMQP Client",
   "author": "FounderNest",
   "default": "./dist/index.js",

--- a/src/amqp-client.ts
+++ b/src/amqp-client.ts
@@ -147,7 +147,7 @@ export class AMQPClient implements AMQPClientInterface {
   async sendMessage<T extends object>(
     queueName: string,
     message: T,
-    { headers, correlationId }: MessagePublishOptions = {}
+    { headers, correlationId, priority }: MessagePublishOptions = {}
   ): Promise<boolean> {
     try {
       if (!this.producer) {
@@ -158,6 +158,7 @@ export class AMQPClient implements AMQPClientInterface {
       return this.producer.sendToQueue(queueName, Buffer.from(JSON.stringify(message)), {
         headers,
         correlationId,
+        priority,
         persistent: true,
         deliveryMode: 2,
         contentType: 'application/json',

--- a/src/amqp-client.types.ts
+++ b/src/amqp-client.types.ts
@@ -2,13 +2,13 @@
  * Represents a message received from an AMQP queue, containing the message content and metadata.
  * @template T - The type of the message content
  */
-export interface AMQPMessage<T = any> {
+export interface AMQPMessage<T = unknown> {
   /** The deserialized message content */
   content: T
   /** Metadata associated with the message */
   metadata: {
     /** Optional headers attached to the message */
-    headers?: Record<string, any>
+    headers?: Record<string, unknown>
     /** Unique identifier used for message correlation and tracking */
     correlationId?: string
     /** Indicates whether this message has been redelivered after a failed processing attempt */
@@ -21,9 +21,11 @@ export interface AMQPMessage<T = any> {
  */
 export interface MessagePublishOptions {
   /** Custom headers to attach to the message */
-  headers?: Record<string, any>
+  headers?: Record<string, unknown>
   /** Unique identifier for message correlation and tracking */
   correlationId?: string
+  /** Message priority (0-255, where higher numbers indicate higher priority) */
+  priority?: number
 }
 
 /**

--- a/tests/amqp-client.spec.ts
+++ b/tests/amqp-client.spec.ts
@@ -96,6 +96,19 @@ describe('AMQPClient', () => {
       )
     })
 
+    it('should send messages with the specified priority', async () => {
+      const client = generateClient()
+      await client.sendMessage('test-queue', { key: 'value' }, { priority: 8 })
+
+      expect(mockChannel.sendToQueue).toHaveBeenCalledWith(
+        'test-queue',
+        Buffer.from(JSON.stringify({ key: 'value' })),
+        expect.objectContaining({
+          priority: 8,
+        })
+      )
+    })
+
     it('should log that the message was sent', () => {
       // If using a custom logger, you can check logger.info was called with correct message
     })


### PR DESCRIPTION
## Documentation checked to make the change
- https://www.rabbitmq.com/docs/quorum-queues#priorities
- https://typestrong.org/typedoc-auto-docs/_types_amqplib/interfaces/MessageProperties.html
- https://www.rabbitmq.com/blog/2024/08/28/quorum-queues-in-4.0


### Feature Enhancement: Message Priority
* [`src/amqp-client.ts`](diffhunk://#diff-f48dd4993c8000f9834768cd663b8cbf1dca59caa4a1715d6c41df68d3c6ddb6L150-R150): Added support for specifying message priority in the `sendMessage` method by extending the `MessagePublishOptions` parameter and ensuring the priority is passed to the AMQP producer. [[1]](diffhunk://#diff-f48dd4993c8000f9834768cd663b8cbf1dca59caa4a1715d6c41df68d3c6ddb6L150-R150) [[2]](diffhunk://#diff-f48dd4993c8000f9834768cd663b8cbf1dca59caa4a1715d6c41df68d3c6ddb6R161)
* [`tests/amqp-client.spec.ts`](diffhunk://#diff-e1ba71feec39788b41221248e3edd46b45ae591c6a92a10d62c58e9d3c19d604R99-R111): Added a new test case to verify that messages are sent with the specified priority, ensuring correct functionality.


### Version Update
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented the library version from `0.2.4` to `0.2.5` to reflect the new feature and type improvements.