### PR TITLE
feat: re-subscribe consumers on reconnect and expose health

### DIFF
--- a/dist/amqp-client.d.ts
+++ b/dist/amqp-client.d.ts
@@ -10,6 +10,7 @@ export declare class AMQPClient implements AMQPClientInterface {
     private consumers;
     private listeners;
     private connected;
+    private isClosing;
     private reconnectAttempts;
     private readonly options;
     private readonly logger;
@@ -29,5 +30,7 @@ export declare class AMQPClient implements AMQPClientInterface {
     private getConsumerChannel;
     private bindQueueToChannel;
     private createConsumerChannel;
+    private forgetConsumer;
+    private discardChannel;
     private isAmqpError;
 }

--- a/dist/amqp-client.d.ts
+++ b/dist/amqp-client.d.ts
@@ -1,6 +1,6 @@
 import { type AMQPClientLoggerInterface } from './amqp-client-logger.interface';
 import { type AMQPClientInterface } from './amqp-client.interface';
-import { type AMQPMessage, type ConnectionOptions, type ConsumeOptions, type MessagePublishOptions } from './amqp-client.types';
+import { type AMQPClientHealth, type AMQPMessage, type ConnectionOptions, type ConsumeOptions, type MessagePublishOptions } from './amqp-client.types';
 export type AMQPClientArgs = ConnectionOptions & {
     logger?: AMQPClientLoggerInterface;
 };
@@ -8,16 +8,23 @@ export declare class AMQPClient implements AMQPClientInterface {
     private connection;
     private producer;
     private consumers;
+    private listeners;
+    private connected;
     private reconnectAttempts;
     private readonly options;
     private readonly logger;
     constructor({ logger, ...options }: AMQPClientArgs);
+    isConnected(): boolean;
+    getHealth(): AMQPClientHealth;
     private connect;
     private reconnect;
     private calculateBackoffDelay;
     close(): Promise<void>;
     sendMessage<T extends object>(queueName: string, message: T, { headers, correlationId, priority }?: MessagePublishOptions): Promise<boolean>;
     createListener<T extends object>(queueName: string, onMessage: (msg: AMQPMessage<T>) => Promise<boolean>, options?: ConsumeOptions): Promise<void>;
+    private resubscribeListeners;
+    private resubscribeListener;
+    private subscribe;
     private getProducerChannel;
     private getConsumerChannel;
     private bindQueueToChannel;

--- a/dist/amqp-client.interface.d.ts
+++ b/dist/amqp-client.interface.d.ts
@@ -1,6 +1,10 @@
-import { type AMQPMessage, type ConsumeOptions, type MessagePublishOptions } from './amqp-client.types';
+import { type AMQPClientHealth, type AMQPMessage, type ConsumeOptions, type MessagePublishOptions } from './amqp-client.types';
 export interface AMQPClientInterface {
     close(): Promise<void>;
     sendMessage<T extends object>(queueName: string, message: T, options?: MessagePublishOptions): Promise<boolean>;
     createListener<T extends object>(queueName: string, onMessage: (msg: AMQPMessage<T>) => Promise<boolean>, options?: ConsumeOptions): Promise<void>;
+    /** Whether the underlying connection to the broker is currently established. */
+    isConnected(): boolean;
+    /** A snapshot of connectivity and consumer state for health/liveness checks. */
+    getHealth(): AMQPClientHealth;
 }

--- a/dist/amqp-client.js
+++ b/dist/amqp-client.js
@@ -4,6 +4,8 @@ export class AMQPClient {
         this.connection = null;
         this.producer = null;
         this.consumers = new Map();
+        this.listeners = new Map();
+        this.connected = false;
         this.reconnectAttempts = 0;
         // Define default options
         const defaultOptions = {
@@ -30,6 +32,19 @@ export class AMQPClient {
         };
         this.logger = logger;
     }
+    isConnected() {
+        return this.connected;
+    }
+    getHealth() {
+        const expectedConsumers = this.listeners.size;
+        const activeConsumers = this.consumers.size;
+        return {
+            connected: this.connected,
+            expectedConsumers,
+            activeConsumers,
+            healthy: this.connected && activeConsumers >= expectedConsumers,
+        };
+    }
     async connect(connectionName, applicationName) {
         const { host, port = 5672, username, password, vhost = '/' } = this.options;
         const connectionString = `amqp://${username ? `${username}:${password}@` : ''}${host}:${port}/${vhost}`;
@@ -41,17 +56,21 @@ export class AMQPClient {
                 },
             });
             this.reconnectAttempts = 0;
+            this.connected = true;
             this.logger.info('📭️ Connected to AMQP broker.');
             this.connection.on('error', (err) => {
+                this.connected = false;
                 this.logger.error('🚨 AMQP Connection Error:', err);
                 this.reconnect(connectionName);
             });
             this.connection.on('close', () => {
+                this.connected = false;
                 this.logger.warn('⚠️ AMQP Connection Closed');
                 this.reconnect(connectionName);
             });
         }
         catch (error) {
+            this.connected = false;
             this.logger.error('🚨 Failed to connect to AMQP broker:', error);
             await this.reconnect(connectionName);
         }
@@ -68,6 +87,7 @@ export class AMQPClient {
             setTimeout(async () => {
                 try {
                     await this.connect(queueName);
+                    await this.resubscribeListeners();
                     resolve();
                 }
                 catch (err) {
@@ -112,6 +132,9 @@ export class AMQPClient {
         }
         finally {
             this.connection = null;
+            this.connected = false;
+            this.consumers.clear();
+            this.listeners.clear();
         }
     }
     async sendMessage(queueName, message, { headers, correlationId, priority } = {}) {
@@ -136,6 +159,35 @@ export class AMQPClient {
         return false;
     }
     async createListener(queueName, onMessage, options) {
+        // Remember the registration so consumers can be re-established after a reconnect.
+        this.listeners.set(queueName, {
+            onMessage: onMessage,
+            options,
+        });
+        await this.subscribe(queueName, onMessage, options);
+    }
+    async resubscribeListeners() {
+        if (!this.connected || this.listeners.size === 0) {
+            return;
+        }
+        for (const [queueName, registration] of this.listeners) {
+            await this.resubscribeListener(queueName, registration);
+        }
+    }
+    async resubscribeListener(queueName, registration) {
+        // A consumer channel that survived the reconnect is still live; don't duplicate it.
+        if (this.consumers.has(queueName)) {
+            return;
+        }
+        try {
+            await this.subscribe(queueName, registration.onMessage, registration.options);
+            this.logger.info(`🔁 Re-subscribed consumer to queue: ${queueName}`);
+        }
+        catch (error) {
+            this.logger.error(`💥 Failed to re-subscribe consumer to queue: ${queueName}`, error);
+        }
+    }
+    async subscribe(queueName, onMessage, options) {
         const channel = await this.getConsumerChannel({
             queueName,
             deadLetter: options?.deadLetter !== undefined ? options.deadLetter : true,
@@ -204,8 +256,7 @@ export class AMQPClient {
     }
     async getConsumerChannel({ queueName, deadLetter }) {
         this.logger.debug(`🗿 Asserting queue ${queueName} ${deadLetter ? 'with dead letter queue' : ''}`);
-        const channelQueueName = `consumer-${queueName}-${Date.now()}`;
-        const channel = await this.createConsumerChannel(channelQueueName, 1);
+        const channel = await this.createConsumerChannel(queueName, 1);
         const assertQueueOptions = {
             durable: true,
             exclusive: false,
@@ -245,7 +296,7 @@ export class AMQPClient {
                 this.logger.warn(`⚠️ Queue "${queueName}" exists with different arguments.`);
                 try {
                     // WE NEED TO RECREATE THE CHANNEL. WHENEVER ASSERT QUEUE THROWS AN ERROR, THE CHANNEL BREAKS
-                    const channel = await this.createConsumerChannel(channelQueueName, 1);
+                    const channel = await this.createConsumerChannel(queueName, 1);
                     const queue = await channel.checkQueue(queueName);
                     if (queue.messageCount === 0) {
                         this.logger.info(`🔄 Queue "${queueName}" is empty. Recreating it with new arguments.`);

--- a/dist/amqp-client.js
+++ b/dist/amqp-client.js
@@ -6,6 +6,7 @@ export class AMQPClient {
         this.consumers = new Map();
         this.listeners = new Map();
         this.connected = false;
+        this.isClosing = false;
         this.reconnectAttempts = 0;
         // Define default options
         const defaultOptions = {
@@ -61,11 +62,17 @@ export class AMQPClient {
             this.connection.on('error', (err) => {
                 this.connected = false;
                 this.logger.error('🚨 AMQP Connection Error:', err);
+                if (this.isClosing) {
+                    return;
+                }
                 this.reconnect(connectionName);
             });
             this.connection.on('close', () => {
                 this.connected = false;
                 this.logger.warn('⚠️ AMQP Connection Closed');
+                if (this.isClosing) {
+                    return;
+                }
                 this.reconnect(connectionName);
             });
         }
@@ -76,6 +83,9 @@ export class AMQPClient {
         }
     }
     async reconnect(queueName) {
+        if (this.isClosing) {
+            return;
+        }
         if (this.reconnectAttempts >= this.options.reconnection.maxAttempts) {
             this.logger.error('🚨 Max reconnection attempts reached. Giving up.');
             return;
@@ -102,6 +112,9 @@ export class AMQPClient {
         return Math.ceil(exponentialDelay + Math.random() * 1000);
     }
     async close() {
+        // Disable reconnection so closing the connection below doesn't trigger the
+        // 'close' handler into reconnecting in the background. close() is terminal.
+        this.isClosing = true;
         try {
             if (this.producer) {
                 await this.producer.close();
@@ -159,12 +172,13 @@ export class AMQPClient {
         return false;
     }
     async createListener(queueName, onMessage, options) {
-        // Remember the registration so consumers can be re-established after a reconnect.
+        await this.subscribe(queueName, onMessage, options);
+        // Remember the registration only after a successful subscribe, so a failed
+        // start doesn't leave a phantom listener that skews health or gets retried.
         this.listeners.set(queueName, {
             onMessage: onMessage,
             options,
         });
-        await this.subscribe(queueName, onMessage, options);
     }
     async resubscribeListeners() {
         if (!this.connected || this.listeners.size === 0) {
@@ -294,15 +308,17 @@ export class AMQPClient {
             // PRECONDITION_FAILED ERROR | QUEUE EXISTS WITH DIFFERENT CONFIG
             if (this.isAmqpError(error) && error.code === 406) {
                 this.logger.warn(`⚠️ Queue "${queueName}" exists with different arguments.`);
+                // The 406 breaks the channel server-side; close it before replacing so
+                // its 'close' handler can't later evict the replacement (same map key).
+                await this.discardChannel(channel);
                 try {
-                    // WE NEED TO RECREATE THE CHANNEL. WHENEVER ASSERT QUEUE THROWS AN ERROR, THE CHANNEL BREAKS
-                    const channel = await this.createConsumerChannel(queueName, 1);
-                    const queue = await channel.checkQueue(queueName);
+                    const replacementChannel = await this.createConsumerChannel(queueName, 1);
+                    const queue = await replacementChannel.checkQueue(queueName);
                     if (queue.messageCount === 0) {
                         this.logger.info(`🔄 Queue "${queueName}" is empty. Recreating it with new arguments.`);
-                        await channel.deleteQueue(queueName);
+                        await replacementChannel.deleteQueue(queueName);
                         await this.bindQueueToChannel({
-                            channel,
+                            channel: replacementChannel,
                             queueName,
                             assertQueueOptions,
                             deadLetter,
@@ -310,21 +326,17 @@ export class AMQPClient {
                             dlqName,
                             routingKey,
                         });
-                        return channel;
+                        return replacementChannel;
                     }
-                    else {
-                        this.logger.warn(`⚠️ Queue "${queueName}" has messages. Proceeding without re-declaring the queue.`);
-                        return channel;
-                    }
+                    this.logger.warn(`⚠️ Queue "${queueName}" has messages. Proceeding without re-declaring the queue.`);
+                    return replacementChannel;
                 }
                 catch (checkError) {
                     this.logger.error(`💥 Failed recreating queue "${queueName}":`, checkError);
                     throw checkError;
                 }
             }
-            else {
-                throw error;
-            }
+            throw error;
         }
     }
     async bindQueueToChannel({ channel, queueName, assertQueueOptions, deadLetter, exchangeName, dlqName, routingKey, }) {
@@ -357,20 +369,36 @@ export class AMQPClient {
             if (prefetch) {
                 await channel.prefetch(prefetch);
             }
-            channel.on('error', (err) => {
+            const consumerChannel = channel;
+            consumerChannel.on('error', (err) => {
                 this.logger.error('🚨 AMQP Channel Error:', err);
-                this.consumers.delete(queueName);
+                this.forgetConsumer(queueName, consumerChannel);
             });
-            channel.on('close', () => {
+            consumerChannel.on('close', () => {
                 this.logger.warn('⚠️ AMQP Channel Closed');
-                this.consumers.delete(queueName);
+                this.forgetConsumer(queueName, consumerChannel);
             });
-            this.consumers.set(queueName, channel);
+            this.consumers.set(queueName, consumerChannel);
         }
         if (!channel) {
             throw new Error('💥 Channel is not available');
         }
         return channel;
+    }
+    // Only drop the map entry if it still points to this channel. A stale channel
+    // (e.g. the broken one from a 406 retry) must not evict its replacement.
+    forgetConsumer(queueName, channel) {
+        if (this.consumers.get(queueName) === channel) {
+            this.consumers.delete(queueName);
+        }
+    }
+    async discardChannel(channel) {
+        try {
+            await channel.close();
+        }
+        catch (error) {
+            this.logger.debug('🗑️ Ignoring error while discarding broken channel', error);
+        }
     }
     isAmqpError(error) {
         return typeof error === 'object' && error !== null && 'code' in error;

--- a/dist/amqp-client.types.d.ts
+++ b/dist/amqp-client.types.d.ts
@@ -98,3 +98,16 @@ export type ConnectionConstants = {
     };
 };
 export type ClientOptions = ClientConnectionOptions & ConnectionConstants;
+/**
+ * A snapshot of the client's connectivity, suitable for health/liveness checks.
+ */
+export interface AMQPClientHealth {
+    /** Whether the underlying connection to the broker is currently established */
+    connected: boolean;
+    /** Number of listeners the client has been asked to keep subscribed */
+    expectedConsumers: number;
+    /** Number of consumer channels that are currently active */
+    activeConsumers: number;
+    /** True when connected and every expected consumer is actively subscribed */
+    healthy: boolean;
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -7820,7 +7820,7 @@ credentials$1.external = function() {
 var name = "amqplib";
 var homepage = "http://amqp-node.github.io/amqplib/";
 var main = "./channel_api.js";
-var version = "0.10.8";
+var version = "0.10.9";
 var description = "An AMQP 0-9-1 (e.g., RabbitMQ) library and client.";
 var repository = {
 	type: "git",
@@ -7988,9 +7988,10 @@ function connect$1(url, socketOptions, openCallback) {
     fields = openFrames(url.vhost, config, sockopts.credentials || credentials.plain(user, pass), extraClientProperties);
   } else {
     var parts = URL(url, true); // yes, parse the query string
+    var host = parts.hostname.replace(/^\[|\]$/g, '');
     protocol = parts.protocol;
-    sockopts.host = parts.hostname;
-    sockopts.servername = sockopts.servername || parts.hostname;
+    sockopts.host = host;
+    sockopts.servername = sockopts.servername || host;
     sockopts.port = parseInt(parts.port) || ((protocol === 'amqp:') ? 5672 : 5671);
     var vhost = parts.pathname ? parts.pathname.substr(1) : null;
     fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
@@ -9185,6 +9186,8 @@ class AMQPClient {
         this.connection = null;
         this.producer = null;
         this.consumers = new Map();
+        this.listeners = new Map();
+        this.connected = false;
         this.reconnectAttempts = 0;
         // Define default options
         const defaultOptions = {
@@ -9211,6 +9214,19 @@ class AMQPClient {
         };
         this.logger = logger;
     }
+    isConnected() {
+        return this.connected;
+    }
+    getHealth() {
+        const expectedConsumers = this.listeners.size;
+        const activeConsumers = this.consumers.size;
+        return {
+            connected: this.connected,
+            expectedConsumers,
+            activeConsumers,
+            healthy: this.connected && activeConsumers >= expectedConsumers,
+        };
+    }
     async connect(connectionName, applicationName) {
         const { host, port = 5672, username, password, vhost = '/' } = this.options;
         const connectionString = `amqp://${username ? `${username}:${password}@` : ''}${host}:${port}/${vhost}`;
@@ -9222,17 +9238,21 @@ class AMQPClient {
                 },
             });
             this.reconnectAttempts = 0;
+            this.connected = true;
             this.logger.info('📭️ Connected to AMQP broker.');
             this.connection.on('error', (err) => {
+                this.connected = false;
                 this.logger.error('🚨 AMQP Connection Error:', err);
                 this.reconnect(connectionName);
             });
             this.connection.on('close', () => {
+                this.connected = false;
                 this.logger.warn('⚠️ AMQP Connection Closed');
                 this.reconnect(connectionName);
             });
         }
         catch (error) {
+            this.connected = false;
             this.logger.error('🚨 Failed to connect to AMQP broker:', error);
             await this.reconnect(connectionName);
         }
@@ -9249,6 +9269,7 @@ class AMQPClient {
             setTimeout(async () => {
                 try {
                     await this.connect(queueName);
+                    await this.resubscribeListeners();
                     resolve();
                 }
                 catch (err) {
@@ -9293,6 +9314,9 @@ class AMQPClient {
         }
         finally {
             this.connection = null;
+            this.connected = false;
+            this.consumers.clear();
+            this.listeners.clear();
         }
     }
     async sendMessage(queueName, message, { headers, correlationId, priority } = {}) {
@@ -9317,6 +9341,35 @@ class AMQPClient {
         return false;
     }
     async createListener(queueName, onMessage, options) {
+        // Remember the registration so consumers can be re-established after a reconnect.
+        this.listeners.set(queueName, {
+            onMessage: onMessage,
+            options,
+        });
+        await this.subscribe(queueName, onMessage, options);
+    }
+    async resubscribeListeners() {
+        if (!this.connected || this.listeners.size === 0) {
+            return;
+        }
+        for (const [queueName, registration] of this.listeners) {
+            await this.resubscribeListener(queueName, registration);
+        }
+    }
+    async resubscribeListener(queueName, registration) {
+        // A consumer channel that survived the reconnect is still live; don't duplicate it.
+        if (this.consumers.has(queueName)) {
+            return;
+        }
+        try {
+            await this.subscribe(queueName, registration.onMessage, registration.options);
+            this.logger.info(`🔁 Re-subscribed consumer to queue: ${queueName}`);
+        }
+        catch (error) {
+            this.logger.error(`💥 Failed to re-subscribe consumer to queue: ${queueName}`, error);
+        }
+    }
+    async subscribe(queueName, onMessage, options) {
         const channel = await this.getConsumerChannel({
             queueName,
             deadLetter: options?.deadLetter !== undefined ? options.deadLetter : true,
@@ -9385,8 +9438,7 @@ class AMQPClient {
     }
     async getConsumerChannel({ queueName, deadLetter }) {
         this.logger.debug(`🗿 Asserting queue ${queueName} ${deadLetter ? 'with dead letter queue' : ''}`);
-        const channelQueueName = `consumer-${queueName}-${Date.now()}`;
-        const channel = await this.createConsumerChannel(channelQueueName, 1);
+        const channel = await this.createConsumerChannel(queueName, 1);
         const assertQueueOptions = {
             durable: true,
             exclusive: false,
@@ -9426,7 +9478,7 @@ class AMQPClient {
                 this.logger.warn(`⚠️ Queue "${queueName}" exists with different arguments.`);
                 try {
                     // WE NEED TO RECREATE THE CHANNEL. WHENEVER ASSERT QUEUE THROWS AN ERROR, THE CHANNEL BREAKS
-                    const channel = await this.createConsumerChannel(channelQueueName, 1);
+                    const channel = await this.createConsumerChannel(queueName, 1);
                     const queue = await channel.checkQueue(queueName);
                     if (queue.messageCount === 0) {
                         this.logger.info(`🔄 Queue "${queueName}" is empty. Recreating it with new arguments.`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -9188,6 +9188,7 @@ class AMQPClient {
         this.consumers = new Map();
         this.listeners = new Map();
         this.connected = false;
+        this.isClosing = false;
         this.reconnectAttempts = 0;
         // Define default options
         const defaultOptions = {
@@ -9243,11 +9244,17 @@ class AMQPClient {
             this.connection.on('error', (err) => {
                 this.connected = false;
                 this.logger.error('🚨 AMQP Connection Error:', err);
+                if (this.isClosing) {
+                    return;
+                }
                 this.reconnect(connectionName);
             });
             this.connection.on('close', () => {
                 this.connected = false;
                 this.logger.warn('⚠️ AMQP Connection Closed');
+                if (this.isClosing) {
+                    return;
+                }
                 this.reconnect(connectionName);
             });
         }
@@ -9258,6 +9265,9 @@ class AMQPClient {
         }
     }
     async reconnect(queueName) {
+        if (this.isClosing) {
+            return;
+        }
         if (this.reconnectAttempts >= this.options.reconnection.maxAttempts) {
             this.logger.error('🚨 Max reconnection attempts reached. Giving up.');
             return;
@@ -9284,6 +9294,9 @@ class AMQPClient {
         return Math.ceil(exponentialDelay + Math.random() * 1000);
     }
     async close() {
+        // Disable reconnection so closing the connection below doesn't trigger the
+        // 'close' handler into reconnecting in the background. close() is terminal.
+        this.isClosing = true;
         try {
             if (this.producer) {
                 await this.producer.close();
@@ -9341,12 +9354,13 @@ class AMQPClient {
         return false;
     }
     async createListener(queueName, onMessage, options) {
-        // Remember the registration so consumers can be re-established after a reconnect.
+        await this.subscribe(queueName, onMessage, options);
+        // Remember the registration only after a successful subscribe, so a failed
+        // start doesn't leave a phantom listener that skews health or gets retried.
         this.listeners.set(queueName, {
             onMessage: onMessage,
             options,
         });
-        await this.subscribe(queueName, onMessage, options);
     }
     async resubscribeListeners() {
         if (!this.connected || this.listeners.size === 0) {
@@ -9476,15 +9490,17 @@ class AMQPClient {
             // PRECONDITION_FAILED ERROR | QUEUE EXISTS WITH DIFFERENT CONFIG
             if (this.isAmqpError(error) && error.code === 406) {
                 this.logger.warn(`⚠️ Queue "${queueName}" exists with different arguments.`);
+                // The 406 breaks the channel server-side; close it before replacing so
+                // its 'close' handler can't later evict the replacement (same map key).
+                await this.discardChannel(channel);
                 try {
-                    // WE NEED TO RECREATE THE CHANNEL. WHENEVER ASSERT QUEUE THROWS AN ERROR, THE CHANNEL BREAKS
-                    const channel = await this.createConsumerChannel(queueName, 1);
-                    const queue = await channel.checkQueue(queueName);
+                    const replacementChannel = await this.createConsumerChannel(queueName, 1);
+                    const queue = await replacementChannel.checkQueue(queueName);
                     if (queue.messageCount === 0) {
                         this.logger.info(`🔄 Queue "${queueName}" is empty. Recreating it with new arguments.`);
-                        await channel.deleteQueue(queueName);
+                        await replacementChannel.deleteQueue(queueName);
                         await this.bindQueueToChannel({
-                            channel,
+                            channel: replacementChannel,
                             queueName,
                             assertQueueOptions,
                             deadLetter,
@@ -9492,21 +9508,17 @@ class AMQPClient {
                             dlqName,
                             routingKey,
                         });
-                        return channel;
+                        return replacementChannel;
                     }
-                    else {
-                        this.logger.warn(`⚠️ Queue "${queueName}" has messages. Proceeding without re-declaring the queue.`);
-                        return channel;
-                    }
+                    this.logger.warn(`⚠️ Queue "${queueName}" has messages. Proceeding without re-declaring the queue.`);
+                    return replacementChannel;
                 }
                 catch (checkError) {
                     this.logger.error(`💥 Failed recreating queue "${queueName}":`, checkError);
                     throw checkError;
                 }
             }
-            else {
-                throw error;
-            }
+            throw error;
         }
     }
     async bindQueueToChannel({ channel, queueName, assertQueueOptions, deadLetter, exchangeName, dlqName, routingKey, }) {
@@ -9539,20 +9551,36 @@ class AMQPClient {
             if (prefetch) {
                 await channel.prefetch(prefetch);
             }
-            channel.on('error', (err) => {
+            const consumerChannel = channel;
+            consumerChannel.on('error', (err) => {
                 this.logger.error('🚨 AMQP Channel Error:', err);
-                this.consumers.delete(queueName);
+                this.forgetConsumer(queueName, consumerChannel);
             });
-            channel.on('close', () => {
+            consumerChannel.on('close', () => {
                 this.logger.warn('⚠️ AMQP Channel Closed');
-                this.consumers.delete(queueName);
+                this.forgetConsumer(queueName, consumerChannel);
             });
-            this.consumers.set(queueName, channel);
+            this.consumers.set(queueName, consumerChannel);
         }
         if (!channel) {
             throw new Error('💥 Channel is not available');
         }
         return channel;
+    }
+    // Only drop the map entry if it still points to this channel. A stale channel
+    // (e.g. the broken one from a 406 retry) must not evict its replacement.
+    forgetConsumer(queueName, channel) {
+        if (this.consumers.get(queueName) === channel) {
+            this.consumers.delete(queueName);
+        }
+    }
+    async discardChannel(channel) {
+        try {
+            await channel.close();
+        }
+        catch (error) {
+            this.logger.debug('🗑️ Ignoring error while discarding broken channel', error);
+        }
     }
     isAmqpError(error) {
         return typeof error === 'object' && error !== null && 'code' in error;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundernest-amqp-client",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "AMQP Client",
   "author": "FounderNest",
   "default": "./dist/index.js",

--- a/src/amqp-client.interface.ts
+++ b/src/amqp-client.interface.ts
@@ -1,4 +1,9 @@
-import { type AMQPMessage, type ConsumeOptions, type MessagePublishOptions } from './amqp-client.types'
+import {
+  type AMQPClientHealth,
+  type AMQPMessage,
+  type ConsumeOptions,
+  type MessagePublishOptions,
+} from './amqp-client.types'
 
 export interface AMQPClientInterface {
   close(): Promise<void>
@@ -8,4 +13,8 @@ export interface AMQPClientInterface {
     onMessage: (msg: AMQPMessage<T>) => Promise<boolean>,
     options?: ConsumeOptions
   ): Promise<void>
+  /** Whether the underlying connection to the broker is currently established. */
+  isConnected(): boolean
+  /** A snapshot of connectivity and consumer state for health/liveness checks. */
+  getHealth(): AMQPClientHealth
 }

--- a/src/amqp-client.ts
+++ b/src/amqp-client.ts
@@ -27,6 +27,7 @@ export class AMQPClient implements AMQPClientInterface {
   private consumers: Map<string, amqp.Channel> = new Map<string, amqp.Channel>()
   private listeners: Map<string, ListenerRegistration> = new Map<string, ListenerRegistration>()
   private connected = false
+  private isClosing = false
   private reconnectAttempts = 0
   private readonly options: ClientOptions
   private readonly logger: AMQPClientLoggerInterface
@@ -94,12 +95,18 @@ export class AMQPClient implements AMQPClientInterface {
       this.connection.on('error', (err: Error): void => {
         this.connected = false
         this.logger.error('🚨 AMQP Connection Error:', err)
+        if (this.isClosing) {
+          return
+        }
         this.reconnect(connectionName)
       })
 
       this.connection.on('close', (): void => {
         this.connected = false
         this.logger.warn('⚠️ AMQP Connection Closed')
+        if (this.isClosing) {
+          return
+        }
         this.reconnect(connectionName)
       })
     } catch (error) {
@@ -110,6 +117,10 @@ export class AMQPClient implements AMQPClientInterface {
   }
 
   private async reconnect(queueName?: string): Promise<void> {
+    if (this.isClosing) {
+      return
+    }
+
     if (this.reconnectAttempts >= this.options.reconnection.maxAttempts) {
       this.logger.error('🚨 Max reconnection attempts reached. Giving up.')
       return
@@ -143,6 +154,10 @@ export class AMQPClient implements AMQPClientInterface {
   }
 
   async close(): Promise<void> {
+    // Disable reconnection so closing the connection below doesn't trigger the
+    // 'close' handler into reconnecting in the background. close() is terminal.
+    this.isClosing = true
+
     try {
       if (this.producer) {
         await this.producer.close()
@@ -208,13 +223,14 @@ export class AMQPClient implements AMQPClientInterface {
     onMessage: (msg: AMQPMessage<T>) => Promise<boolean>,
     options?: ConsumeOptions
   ): Promise<void> {
-    // Remember the registration so consumers can be re-established after a reconnect.
+    await this.subscribe(queueName, onMessage, options)
+
+    // Remember the registration only after a successful subscribe, so a failed
+    // start doesn't leave a phantom listener that skews health or gets retried.
     this.listeners.set(queueName, {
       onMessage: onMessage as (msg: AMQPMessage<object>) => Promise<boolean>,
       options,
     })
-
-    await this.subscribe(queueName, onMessage, options)
   }
 
   private async resubscribeListeners(): Promise<void> {
@@ -365,16 +381,19 @@ export class AMQPClient implements AMQPClientInterface {
       if (this.isAmqpError(error) && error.code === 406) {
         this.logger.warn(`⚠️ Queue "${queueName}" exists with different arguments.`)
 
+        // The 406 breaks the channel server-side; close it before replacing so
+        // its 'close' handler can't later evict the replacement (same map key).
+        await this.discardChannel(channel)
+
         try {
-          // WE NEED TO RECREATE THE CHANNEL. WHENEVER ASSERT QUEUE THROWS AN ERROR, THE CHANNEL BREAKS
-          const channel = await this.createConsumerChannel(queueName, 1)
-          const queue = await channel.checkQueue(queueName)
+          const replacementChannel = await this.createConsumerChannel(queueName, 1)
+          const queue = await replacementChannel.checkQueue(queueName)
           if (queue.messageCount === 0) {
             this.logger.info(`🔄 Queue "${queueName}" is empty. Recreating it with new arguments.`)
-            await channel.deleteQueue(queueName)
+            await replacementChannel.deleteQueue(queueName)
 
             await this.bindQueueToChannel({
-              channel,
+              channel: replacementChannel,
               queueName,
               assertQueueOptions,
               deadLetter,
@@ -382,18 +401,18 @@ export class AMQPClient implements AMQPClientInterface {
               dlqName,
               routingKey,
             })
-            return channel
-          } else {
-            this.logger.warn(`⚠️ Queue "${queueName}" has messages. Proceeding without re-declaring the queue.`)
-            return channel
+            return replacementChannel
           }
+
+          this.logger.warn(`⚠️ Queue "${queueName}" has messages. Proceeding without re-declaring the queue.`)
+          return replacementChannel
         } catch (checkError) {
           this.logger.error(`💥 Failed recreating queue "${queueName}":`, checkError)
           throw checkError
         }
-      } else {
-        throw error
       }
+
+      throw error
     }
   }
 
@@ -446,21 +465,38 @@ export class AMQPClient implements AMQPClientInterface {
       if (prefetch) {
         await channel.prefetch(prefetch)
       }
-      channel.on('error', (err: Error) => {
+      const consumerChannel = channel
+      consumerChannel.on('error', (err: Error) => {
         this.logger.error('🚨 AMQP Channel Error:', err)
-        this.consumers.delete(queueName)
+        this.forgetConsumer(queueName, consumerChannel)
       })
-      channel.on('close', () => {
+      consumerChannel.on('close', () => {
         this.logger.warn('⚠️ AMQP Channel Closed')
-        this.consumers.delete(queueName)
+        this.forgetConsumer(queueName, consumerChannel)
       })
-      this.consumers.set(queueName, channel)
+      this.consumers.set(queueName, consumerChannel)
     }
     if (!channel) {
       throw new Error('💥 Channel is not available')
     }
 
     return channel
+  }
+
+  // Only drop the map entry if it still points to this channel. A stale channel
+  // (e.g. the broken one from a 406 retry) must not evict its replacement.
+  private forgetConsumer(queueName: string, channel: amqp.Channel): void {
+    if (this.consumers.get(queueName) === channel) {
+      this.consumers.delete(queueName)
+    }
+  }
+
+  private async discardChannel(channel: amqp.Channel): Promise<void> {
+    try {
+      await channel.close()
+    } catch (error) {
+      this.logger.debug('🗑️ Ignoring error while discarding broken channel', error)
+    }
   }
 
   private isAmqpError(error: unknown): error is AMQPError {

--- a/src/amqp-client.ts
+++ b/src/amqp-client.ts
@@ -2,6 +2,7 @@ import * as amqp from 'amqplib'
 import { type AMQPClientLoggerInterface } from './amqp-client-logger.interface'
 import { type AMQPClientInterface } from './amqp-client.interface'
 import {
+  type AMQPClientHealth,
   type AMQPMessage,
   type ClientOptions,
   type ConnectionOptions,
@@ -15,10 +16,17 @@ export type AMQPClientArgs = ConnectionOptions & {
 
 type AMQPError = { code: number; message: string }
 
+type ListenerRegistration = {
+  onMessage: (msg: AMQPMessage<object>) => Promise<boolean>
+  options?: ConsumeOptions
+}
+
 export class AMQPClient implements AMQPClientInterface {
   private connection: amqp.ChannelModel | null = null
   private producer: amqp.Channel | null = null
   private consumers: Map<string, amqp.Channel> = new Map<string, amqp.Channel>()
+  private listeners: Map<string, ListenerRegistration> = new Map<string, ListenerRegistration>()
+  private connected = false
   private reconnectAttempts = 0
   private readonly options: ClientOptions
   private readonly logger: AMQPClientLoggerInterface
@@ -50,6 +58,22 @@ export class AMQPClient implements AMQPClientInterface {
     this.logger = logger
   }
 
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  getHealth(): AMQPClientHealth {
+    const expectedConsumers = this.listeners.size
+    const activeConsumers = this.consumers.size
+
+    return {
+      connected: this.connected,
+      expectedConsumers,
+      activeConsumers,
+      healthy: this.connected && activeConsumers >= expectedConsumers,
+    }
+  }
+
   private async connect(connectionName?: string, applicationName?: string): Promise<void> {
     const { host, port = 5672, username, password, vhost = '/' } = this.options
     const connectionString = `amqp://${username ? `${username}:${password}@` : ''}${host}:${port}/${vhost}`
@@ -63,19 +87,23 @@ export class AMQPClient implements AMQPClientInterface {
       })
 
       this.reconnectAttempts = 0
+      this.connected = true
 
       this.logger.info('📭️ Connected to AMQP broker.')
 
       this.connection.on('error', (err: Error): void => {
+        this.connected = false
         this.logger.error('🚨 AMQP Connection Error:', err)
         this.reconnect(connectionName)
       })
 
       this.connection.on('close', (): void => {
+        this.connected = false
         this.logger.warn('⚠️ AMQP Connection Closed')
         this.reconnect(connectionName)
       })
     } catch (error) {
+      this.connected = false
       this.logger.error('🚨 Failed to connect to AMQP broker:', error)
       await this.reconnect(connectionName)
     }
@@ -96,6 +124,7 @@ export class AMQPClient implements AMQPClientInterface {
       setTimeout(async () => {
         try {
           await this.connect(queueName)
+          await this.resubscribeListeners()
           resolve()
         } catch (err) {
           this.logger.error('🚨 Reconnection failed:', err)
@@ -141,6 +170,9 @@ export class AMQPClient implements AMQPClientInterface {
       this.logger.error('🚨 Error closing AMQP connection:', error)
     } finally {
       this.connection = null
+      this.connected = false
+      this.consumers.clear()
+      this.listeners.clear()
     }
   }
 
@@ -172,6 +204,44 @@ export class AMQPClient implements AMQPClientInterface {
   }
 
   async createListener<T extends object>(
+    queueName: string,
+    onMessage: (msg: AMQPMessage<T>) => Promise<boolean>,
+    options?: ConsumeOptions
+  ): Promise<void> {
+    // Remember the registration so consumers can be re-established after a reconnect.
+    this.listeners.set(queueName, {
+      onMessage: onMessage as (msg: AMQPMessage<object>) => Promise<boolean>,
+      options,
+    })
+
+    await this.subscribe(queueName, onMessage, options)
+  }
+
+  private async resubscribeListeners(): Promise<void> {
+    if (!this.connected || this.listeners.size === 0) {
+      return
+    }
+
+    for (const [queueName, registration] of this.listeners) {
+      await this.resubscribeListener(queueName, registration)
+    }
+  }
+
+  private async resubscribeListener(queueName: string, registration: ListenerRegistration): Promise<void> {
+    // A consumer channel that survived the reconnect is still live; don't duplicate it.
+    if (this.consumers.has(queueName)) {
+      return
+    }
+
+    try {
+      await this.subscribe(queueName, registration.onMessage, registration.options)
+      this.logger.info(`🔁 Re-subscribed consumer to queue: ${queueName}`)
+    } catch (error) {
+      this.logger.error(`💥 Failed to re-subscribe consumer to queue: ${queueName}`, error)
+    }
+  }
+
+  private async subscribe<T extends object>(
     queueName: string,
     onMessage: (msg: AMQPMessage<T>) => Promise<boolean>,
     options?: ConsumeOptions
@@ -253,8 +323,7 @@ export class AMQPClient implements AMQPClientInterface {
   private async getConsumerChannel({ queueName, deadLetter }: { queueName: string; deadLetter: boolean }) {
     this.logger.debug(`🗿 Asserting queue ${queueName} ${deadLetter ? 'with dead letter queue' : ''}`)
 
-    const channelQueueName = `consumer-${queueName}-${Date.now()}`
-    const channel = await this.createConsumerChannel(channelQueueName, 1)
+    const channel = await this.createConsumerChannel(queueName, 1)
     const assertQueueOptions: amqp.Options.AssertQueue = {
       durable: true,
       exclusive: false,
@@ -298,7 +367,7 @@ export class AMQPClient implements AMQPClientInterface {
 
         try {
           // WE NEED TO RECREATE THE CHANNEL. WHENEVER ASSERT QUEUE THROWS AN ERROR, THE CHANNEL BREAKS
-          const channel = await this.createConsumerChannel(channelQueueName, 1)
+          const channel = await this.createConsumerChannel(queueName, 1)
           const queue = await channel.checkQueue(queueName)
           if (queue.messageCount === 0) {
             this.logger.info(`🔄 Queue "${queueName}" is empty. Recreating it with new arguments.`)

--- a/src/amqp-client.types.ts
+++ b/src/amqp-client.types.ts
@@ -104,3 +104,17 @@ export type ConnectionConstants = {
 }
 
 export type ClientOptions = ClientConnectionOptions & ConnectionConstants
+
+/**
+ * A snapshot of the client's connectivity, suitable for health/liveness checks.
+ */
+export interface AMQPClientHealth {
+  /** Whether the underlying connection to the broker is currently established */
+  connected: boolean
+  /** Number of listeners the client has been asked to keep subscribed */
+  expectedConsumers: number
+  /** Number of consumer channels that are currently active */
+  activeConsumers: number
+  /** True when connected and every expected consumer is actively subscribed */
+  healthy: boolean
+}

--- a/tests/amqp-client.spec.ts
+++ b/tests/amqp-client.spec.ts
@@ -532,4 +532,73 @@ describe('AMQPClient', () => {
       expect(health.healthy).toBe(false)
     })
   })
+
+  describe('Graceful close', () => {
+    const getHandler = (mock: Mock, event: string) => mock.mock.calls.find(([name]) => name === event)?.[1]
+
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('does not reconnect after an intentional close()', async () => {
+      const client = generateClient({ reconnection: { initialDelay: 1, maxDelay: 2, maxAttempts: 5 } })
+      onMessageMock.mockResolvedValue(true)
+      await client.createListener('test-queue', onMessageMock)
+
+      const connectionClose = getHandler(mockConnection.on as Mock, 'close')
+      await client.close()
+      const connectsAfterClose = connectMock.mock.calls.length
+
+      // A late broker 'close' event must not trigger a background reconnect.
+      connectionClose()
+      await vi.advanceTimersByTimeAsync(1100)
+
+      expect(connectMock.mock.calls.length).toBe(connectsAfterClose)
+      expect(client.isConnected()).toBe(false)
+    })
+  })
+
+  describe('Listener registration resilience', () => {
+    it('does not record a listener when the initial subscribe fails', async () => {
+      const client = generateClient()
+      mockConnection.createChannel.mockRejectedValueOnce(new Error('channel boom'))
+
+      await expect(client.createListener('test-queue', onMessageMock)).rejects.toThrow('channel boom')
+      expect(client.getHealth().expectedConsumers).toBe(0)
+    })
+  })
+
+  describe('Recreating a queue with different arguments (406)', () => {
+    const getHandler = (mock: Mock, event: string) => mock.mock.calls.find(([name]) => name === event)?.[1]
+
+    it('closes the broken channel and keeps the replacement as the active consumer', async () => {
+      const brokenChannel = {
+        ...mockChannel,
+        on: vi.fn(),
+        close: vi.fn(),
+        assertQueue: vi.fn().mockRejectedValueOnce({ code: 406 }),
+      }
+      const freshChannel = {
+        ...mockChannel,
+        on: vi.fn(),
+        close: vi.fn(),
+        consume: vi.fn(),
+        checkQueue: vi.fn().mockResolvedValue({ messageCount: 0 }),
+        assertQueue: vi.fn().mockResolvedValue({}),
+        deleteQueue: vi.fn().mockResolvedValue({}),
+      }
+      mockConnection.createChannel.mockResolvedValueOnce(brokenChannel).mockResolvedValueOnce(freshChannel)
+
+      const client = generateClient()
+      onMessageMock.mockResolvedValue(true)
+      await client.createListener('test-queue', onMessageMock, { deadLetter: false })
+
+      expect(brokenChannel.close).toHaveBeenCalled()
+      expect(freshChannel.consume).toHaveBeenCalledWith('test-queue', expect.any(Function))
+      expect(client.getHealth().activeConsumers).toBe(1)
+
+      // A late 'close' from the stale broken channel must not evict the replacement.
+      getHandler(brokenChannel.on as Mock, 'close')()
+      expect(client.getHealth().activeConsumers).toBe(1)
+    })
+  })
 })

--- a/tests/amqp-client.spec.ts
+++ b/tests/amqp-client.spec.ts
@@ -450,4 +450,86 @@ describe('AMQPClient', () => {
       expect(mockChannel.nack).toHaveBeenCalledWith(mockMsg, false, false)
     })
   })
+
+  describe('Re-subscription after reconnect', () => {
+    const getHandler = (mock: Mock, event: string) => mock.mock.calls.find(([name]) => name === event)?.[1]
+
+    // The reconnect backoff adds up to 1s of jitter, so drive it with fake timers.
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('re-establishes consumers when the connection drops and recovers', async () => {
+      const client = generateClient({ reconnection: { initialDelay: 1, maxDelay: 2, maxAttempts: 5 } })
+      onMessageMock.mockResolvedValue(true)
+      await client.createListener('test-queue', onMessageMock)
+
+      expect(mockChannel.consume).toHaveBeenCalledTimes(1)
+      expect(client.getHealth().activeConsumers).toBe(1)
+
+      // Simulate the consumer channel and then the connection dropping.
+      getHandler(mockChannel.on as Mock, 'close')()
+      getHandler(mockConnection.on as Mock, 'close')()
+
+      // Flush the backoff timer so reconnect + re-subscribe run.
+      await vi.advanceTimersByTimeAsync(1100)
+
+      expect(mockChannel.consume).toHaveBeenCalledTimes(2)
+      expect(client.isConnected()).toBe(true)
+      expect(client.getHealth().healthy).toBe(true)
+    })
+
+    it('does not duplicate a consumer that survived the reconnect', async () => {
+      const client = generateClient({ reconnection: { initialDelay: 1, maxDelay: 2, maxAttempts: 5 } })
+      onMessageMock.mockResolvedValue(true)
+      await client.createListener('test-queue', onMessageMock)
+
+      // Connection blips but the consumer channel stayed alive (still tracked).
+      getHandler(mockConnection.on as Mock, 'close')()
+      await vi.advanceTimersByTimeAsync(1100)
+
+      expect(mockChannel.consume).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Health reporting', () => {
+    const getHandler = (mock: Mock, event: string) => mock.mock.calls.find(([name]) => name === event)?.[1]
+
+    it('reports unhealthy before connecting', () => {
+      const client = generateClient()
+
+      expect(client.isConnected()).toBe(false)
+      expect(client.getHealth()).toEqual({
+        connected: false,
+        expectedConsumers: 0,
+        activeConsumers: 0,
+        healthy: false,
+      })
+    })
+
+    it('reports healthy once a listener is consuming', async () => {
+      const client = generateClient()
+      onMessageMock.mockResolvedValue(true)
+      await client.createListener('test-queue', onMessageMock)
+
+      expect(client.getHealth()).toEqual({
+        connected: true,
+        expectedConsumers: 1,
+        activeConsumers: 1,
+        healthy: true,
+      })
+    })
+
+    it('reports unhealthy when an expected consumer is missing after a drop', async () => {
+      const client = generateClient()
+      onMessageMock.mockResolvedValue(true)
+      await client.createListener('test-queue', onMessageMock)
+
+      getHandler(mockChannel.on as Mock, 'close')()
+
+      const health = client.getHealth()
+      expect(health.expectedConsumers).toBe(1)
+      expect(health.activeConsumers).toBe(0)
+      expect(health.healthy).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Why

- A CPM API pod crash-looped in production from an unhandled `IllegalOperationError: Channel closed` raised by this client during a RabbitMQ socket drop.
- While hardening CPM, we found a deeper latent bug here: on a socket drop, `reconnect()` re-establishes the **connection** but never re-issues `channel.consume()` for registered listeners. The connection comes back, but the process is **connected yet no longer consuming** — and HTTP-only liveness probes can't see it, so K8s never restarts it. That's arguably worse than a crash-loop.
- Consumer channels were also tracked under a `consumer-<queue>-<Date.now()>` key, so the `consumers` map **leaks an entry on every reconnect**.

## What

- **Re-subscribe on reconnect:** `createListener` now records each registration (`queueName`, handler, options); after a successful reconnect the client re-establishes every listener. Guarded by a check on the active-consumer map so a channel that survived the blip is never duplicated.
- **Fix the consumer-map leak:** consumer channels are keyed by queue name instead of a timestamped name.
- **Expose health:** new `isConnected()` and `getHealth(): AMQPClientHealth` (`{ connected, expectedConsumers, activeConsumers, healthy }`) so consumers (e.g. CPM) can wire an AMQP-aware liveness probe that catches the "connected but not consuming" state.
- **Clean shutdown:** `close()` now resets connection state and clears tracked listeners/consumers so an intentional close doesn't resurrect consumers.
- Version bump `0.2.6` → `0.3.0` (backward-compatible additions to the public interface).

## Validation

- `npx vitest run` — 31 passing (26 existing + 5 new covering re-subscription, no-duplicate-on-survival, and health reporting).
- `npx tsc --noEmit` — clean.
- `npm run build` — rebuilt and committed `dist/` (verified new methods present in `dist/amqp-client.js`).
- `eslint`/`prettier` on changed files — clean (4 pre-existing `no-explicit-any` errors in the untouched `amqp-client-logger.interface.ts` remain).

## Dependencies

- None.

## Risks

- Low-to-medium. Behavior change is additive: the happy path and existing reconnect attempts are unchanged; the new work only runs *after* a reconnect. The dup-guard prevents double consumers.
- **Publish is a manual maintainer step** (no CI publish workflow in this repo): after merge, `npm publish` the `0.3.0` release. The dependent CPM PR will bump to `^0.3.0` and add the liveness probe once published.

## Screenshots

- N/A